### PR TITLE
Adding normalization to workflow

### DIFF
--- a/.github/workflows/cronjob_update.yml
+++ b/.github/workflows/cronjob_update.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           git config --global user.email "gh_robot@pioneershub.org"
           git config --global user.name "Repo Cronjob GitHub Actions"
+          git config --global user.name merge.renormalize true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
We experience merge conflicts on identical files.

merge.renormalize tells Git to re-apply text normalization rules during merges. This helps handle files that may appear different due to line endings (CRLF vs LF) or other text normalization issues, even when their content is identical.