### PR TITLE
Obfuscate member name in log message for downloaded images

### DIFF
--- a/team_page/process.py
+++ b/team_page/process.py
@@ -147,7 +147,7 @@ class UpdateTeamPage:
                     file.write(chunk)
                 self.repo.git.add(str(member_image))
 
-            log.info(f"Image {member.name} downloaded successfully and saved")
+            log.info(f"Image {obfuscate_name(member.name)} downloaded successfully and saved")
 
         except requests.exceptions.RequestException as e:
             log.info(f"Failed to download the image: {e}")


### PR DESCRIPTION
Obfuscate the member name in the log message when an image is downloaded to enhance privacy.