### PR TITLE
Handle KeyError in TeamMember creation

### DIFF
--- a/team_page/process.py
+++ b/team_page/process.py
@@ -74,7 +74,7 @@ class UpdateTeamPage:
             try:
                 member = TeamMember(**record)
                 members[record.get("committee", "other")].append(member)
-            except ValidationError as e:
+            except (ValidationError, KeyError) as e:
                 log.error(f"Failed to create TeamMember: {e}")
                 continue
             self.download_member_image(member)


### PR DESCRIPTION
Prevent program interruption by handling KeyError during TeamMember creation. This change ensures that errors related to missing keys do not disrupt the program flow.