### PR TITLE
Handle previously unhandled exceptions

### DIFF
--- a/team_page/process.py
+++ b/team_page/process.py
@@ -78,7 +78,7 @@ class UpdateTeamPage:
                 member.image_url = None
                 member.image_name = image_name
                 members[record.get("committee", "other")].append(member)
-            except (ValidationError, KeyError) as e:
+            except (ValidationError, KeyError, ValueError) as e:
                 log.error(f"Failed to create TeamMember: {e}")
                 continue
 


### PR DESCRIPTION
Handle previously unhandled exceptions during image downloads to prevent interruptions in the workflow.