### PR TITLE
Target update_teampage branch and fix image search

### DIFF
--- a/team_page/config.yml
+++ b/team_page/config.yml
@@ -4,7 +4,7 @@
 team_images: "assets/static/media/team/"
 team_images_url: "/static/media/team/"
 default_image: "/static/media/team/gender_neutral_user.png"
-data_bag: "databags/team.json"
+data_bag: "databags/team.yaml"
 # destination url
 # #########################################
 # MAP G-SHEET COLUMNS TO KEYS
@@ -43,6 +43,7 @@ git_repo_url: "https://github.com/PioneersHub/pyconde-website"
 local_repo_path: "repo"
 # branch to make changes in
 branch_name: "auto-update-team-page"
+pr_base_branch: "update_teampage"
 repo_owner: "PioneersHub"
 repo_name: "pyconde-website"
 pr_reviewers:

--- a/team_page/main.py
+++ b/team_page/main.py
@@ -19,7 +19,6 @@ def main():
     if args.mode == "local":
         updater.get_repo()
         data_bag = updater.create_databag()
-        updater.save_json(data_bag)
         updater.save_yaml(data_bag)
         log.info("Local update completed.")
     elif args.mode == "full":


### PR DESCRIPTION
## Summary
- Add `pr_base_branch` config to target `update_teampage` instead of `main`
- Branch working branch from `update_teampage` base
- Use non-recursive `iterdir()` for image lookup to avoid matching stale `.jpg` files from old year subfolders
- Remove dead `save_json()` call from local mode
- Update `data_bag` config value from `.json` to `.yaml`

## Test plan
- [x] Verified locally: `uv run python -m team_page --mode full` runs successfully
- [x] PR #222 created on pyconde-website targeting `update_teampage`
- [x] YAML output has consistent `.jpeg` extensions (no `.jpg` mixing)
- [x] Ruff passes